### PR TITLE
Ignore return value in tests and usage examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,8 @@ $ npm install --save to-fast-properties
 ```js
 var toFastProperties = require('to-fast-properties');
 var obj = {unicorn: true};
-var objWithFastProperties = toFastProperties(obj);
+toFastProperties(obj);
+// Now `obj` has fast properties.
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -2,14 +2,21 @@
 var test = require('ava');
 var toFastProperties = require('./');
 
+var toSlowProperties = function (obj) {
+	for (var i = 0; i < 1000; ++i) {
+		obj['foo' + i] = 'foo';
+	}
+	return obj;
+};
+
 test(function (t) {
-	var obj = [];
-	obj[-1] = 'foo';
+	var obj = toSlowProperties({});
+	obj.foo = 'foo';
 	t.assert(!%HasFastProperties(obj));
 
 	toFastProperties(obj);
-	t.assert(obj[-1] === 'foo');
 	t.assert(%HasFastProperties(obj));
+	t.assert(obj.foo === 'foo');
 
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -3,6 +3,13 @@ var test = require('ava');
 var toFastProperties = require('./');
 
 test(function (t) {
-	t.assert(%HasFastProperties(toFastProperties({})));
+	var obj = [];
+	obj[-1] = 'foo';
+	t.assert(!%HasFastProperties(obj));
+
+	toFastProperties(obj);
+	t.assert(obj[-1] === 'foo');
+	t.assert(%HasFastProperties(obj));
+
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -12,11 +12,11 @@ var toSlowProperties = function (obj) {
 test(function (t) {
 	var obj = toSlowProperties({});
 	obj.foo = 'foo';
-	t.assert(!%HasFastProperties(obj));
+	t.assert(!%HasFastProperties(obj), 'obj has slow properties');
 
 	toFastProperties(obj);
-	t.assert(%HasFastProperties(obj));
-	t.assert(obj.foo === 'foo');
+	t.assert(%HasFastProperties(obj), 'obj has fast properties');
+	t.assert(obj.foo === 'foo', 'obj has the same keys');
 
 	t.end();
 });


### PR DESCRIPTION
``` js
t.assert(%HasFastProperties(toFastProperties({})));
```

This has some issues.
- First and foremost, `toFastProperties` is not used like that! It returns a function, as you can see from the source, and this function does not share the same set of properties with the object passed in.

``` js
toFastProperties({ foo: 'bar' }).foo // undefined
```

`toFastProperties` modifies the internal representation of the object itself. You can check [how it's used in Bluebird](https://github.com/petkaantonov/bluebird/blob/734a16f437f23d66e4bbe9ae51668589f91f940d/src/promisify.js#L253) for reference.
- Secondly, `{}` has fast properties already.

``` js
%HasFastProperties({}) // true
```

There is no reason why it shouldn't have. “Fast properties” is the default mode in V8, unless you do something crazy enough. So this test doesn't actually test anything.
