### PR TITLE
Make it work on modern Node.js versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 'use strict';
-module.exports = function toFastProperties(obj) {
-	function f() {}
-	f.prototype = obj;
-	new f();
-	return;
-	eval(obj);
-};
+module.exports = function toFastproperties(o) {
+	function Sub() {}
+	Sub.prototype = o;
+	var receiver = new Sub(); // create an instance
+	function ic() { return typeof receiver.foo; } // perform access
+	ic(); 
+	ic();
+	return o;
+	eval("o" + o); // ensure no dead code elimination
+}


### PR DESCRIPTION
Can verify with modern node with natives syntax that the current content is no longer optimized whereas this version works in Node 7.

```js
console.log(%HasFastProperties(o));
```