### PR TITLE
Avoid throw away functions and eval trickery

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,27 @@
 'use strict';
-module.exports = function toFastproperties(o) {
-	function Sub() {}
-	Sub.prototype = o;
-	const receiver = new Sub(); // Create an instance
-	function ic() {
-		return typeof receiver.foo; // Perform access
+
+let fastProto = null;
+
+// Creates an object with permanently fast properties in V8. See Toon Verwaest's
+// post https://medium.com/@tverwaes/setting-up-prototypes-in-v8-ec9c9491dfe2#5f62
+// for more details. Use %HasFastProperties(object) and the Node flag
+// --allow-natives-syntax to check whether an object has fast properties.
+function FastObject(o) {
+	// A prototype object will have "fast properties" enabled once it is checked
+	// against the inline property cache of a function, e.g. fastProto.property:
+	// https://github.com/v8/v8/blob/6.0.122/test/mjsunit/fast-prototype.js#L48-L63
+	if (fastProto !== null && typeof fastProto.property) {
+		const result = fastProto;
+		fastProto = FastObject.prototype = null;
+		return result;
 	}
-	ic();
-	ic();
-	return o;
-	eval('o' + o); // Ensure no dead code elimination
+	fastProto = FastObject.prototype = o == null ? Object.create(null) : o;
+	return new FastObject;
+}
+
+// Initialize the inline property cache of FastObject.
+FastObject();
+
+module.exports = function toFastproperties(o) {
+	return FastObject(o);
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ let fastProto = null;
 
 // Creates an object with permanently fast properties in V8. See Toon Verwaest's
 // post https://medium.com/@tverwaes/setting-up-prototypes-in-v8-ec9c9491dfe2#5f62
-// for more details. Use %HasFastProperties(object) and the Node flag
+// for more details. Use %HasFastProperties(object) and the Node.js flag
 // --allow-natives-syntax to check whether an object has fast properties.
 function FastObject(o) {
 	// A prototype object will have "fast properties" enabled once it is checked
@@ -19,7 +19,7 @@ function FastObject(o) {
 	return new FastObject;
 }
 
-// Initialize the inline property cache of FastObject.
+// Initialize the inline property cache of FastObject
 FastObject();
 
 module.exports = function toFastproperties(o) {

--- a/readme.md
+++ b/readme.md
@@ -34,4 +34,4 @@ toFastProperties(obj);
 
 ## License
 
-MIT © Petka Antonov, Sindre Sorhus
+MIT © Petka Antonov, John-David Dalton, Sindre Sorhus


### PR DESCRIPTION
Related to the discussion at https://github.com/sindresorhus/to-fast-properties/pull/7#issuecomment-298243859.

I cleaned up the method to avoid throw away functions and eval trickery.
I also documented the technique a bit more.